### PR TITLE
Documentation: add reference to cargo update

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,7 +95,11 @@ In <a href="http://doc.rust-lang.org/nightly/book/hello-cargo.html#a-new-project
 
 <div class="highlight highlight-bash"><pre>cargo build</pre></div>
 
-<p>and executed with</p>
+<p>If dependencies in your project are out of date, update with</p>
+
+<div class="highlight highlight-bash"><pre>cargo update</pre></div>
+
+<p>Execute the compiled code with</p>
 
 <div class="highlight highlight-bash"><pre>cargo run</pre></div>
 


### PR DESCRIPTION
This helps for confused new rust users who aren't sure why they
persistently get old versions of rust-bio when compiling.
